### PR TITLE
Hard-code language display names, remove gettext wrapping

### DIFF
--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -58,24 +58,18 @@ class SettingsConstants:
     LOCALE__RUSSIAN = "ru"
     LOCALE__SPANISH = "es"
     ALL_LOCALES = [
-        # TRANSLATOR_NOTE: Translator is expected ONLY to change their own locale below
-        (LOCALE__ARABIC, _("Arabic")),
-        (LOCALE__CZECH, _("Czech")),
+        # (LOCALE__ARABIC, "Arabic"),
+        (LOCALE__CZECH, "čeština"),
         (LOCALE__ENGLISH, "English"),
-        (LOCALE__FRENCH, _("French")),
-        (LOCALE__GERMAN, _("German")),
-        (LOCALE__HEBREW, _("Hebrew")),
-        (LOCALE__JAPANESE, _("Japanese")),
-        (LOCALE__KOREAN, _("Korean")),
-        (LOCALE__PORTUGUESE, _("Portuguese")),
-        (LOCALE__RUSSIAN, _("Russian")),
-        (LOCALE__SPANISH, _("Spanish")),
+        (LOCALE__FRENCH, "Français"),
+        (LOCALE__GERMAN, "Deutsch"),
+        # (LOCALE__HEBREW, "Hebrew"),
+        # (LOCALE__JAPANESE, "Japanese"),
+        # (LOCALE__KOREAN, "Korean"),
+        (LOCALE__PORTUGUESE, "Português"),
+        (LOCALE__RUSSIAN, "русский"),
+        (LOCALE__SPANISH, "Español"),
     ]
-    # Some locales disabled below
-    ALL_LOCALES.remove((LOCALE__ARABIC, _("Arabic")))
-    ALL_LOCALES.remove((LOCALE__HEBREW, _("Hebrew")))
-    ALL_LOCALES.remove((LOCALE__JAPANESE, _("Japanese")))
-    ALL_LOCALES.remove((LOCALE__KOREAN, _("Korean")))
 
     BTC_DENOMINATION__BTC = "btc"
     BTC_DENOMINATION__SATS = "sats"


### PR DESCRIPTION
## Description

Language selection should present itself in each language's native way of referring to itself, using its native character set.

Thus there's no need to wrap them for gettext translation.

PR also simplifies how languages are temporarily disabled.

![SettingsEntryUpdateSelectionView_locale](https://github.com/user-attachments/assets/9b315e4b-7f07-45d2-8d25-71a818dc6170)

---

This pull request is categorized as a:
- [x] Code refactor

## Checklist

- [x] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [x] N/A

I have tested this PR on the following platforms/os:

- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
